### PR TITLE
Allow empty 'error' to be in repsonse.

### DIFF
--- a/jsonrpc_base/jsonrpc.py
+++ b/jsonrpc_base/jsonrpc.py
@@ -175,7 +175,7 @@ class Request(Message):
 
         if not isinstance(data, dict):
             raise ProtocolError('Response is not a dictionary')
-        if 'error' in data:
+        if data.get('error') is not None:
             code = data['error'].get('code', '')
             message = data['error'].get('message', '')
             raise ProtocolError(code, message, data)

--- a/tests.py
+++ b/tests.py
@@ -372,6 +372,19 @@ class TestJSONRPCClient(TestCase):
         request = jsonrpc_base.Request('test_method', msg_id=1)
         self.assertEqual(request.response_id, 1)
 
+    def test_jsonrpc_1_0_call(self):
+        # JSON-RPC 1.0 spec needs "error" to be present (with `null` value) when no error occured
+        def handler(message):
+            self.assertEqual(message.params, [42, 23])
+            return {
+                "result": 19,
+                "id": 1,
+                "error": None,
+            }
+
+        self.server._handler = handler
+        self.assertEqual(self.server.subtract(42, 23), 19)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 
+envlist =
     py27,
     py34,
     py35,
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/jsonrpc_base
-commands = 
+commands =
     coverage run tests.py
     coverage report
 deps =
@@ -29,7 +29,7 @@ basepython = python3.5
 deps =
     {[testenv]deps}
 
-[testenv:py35]
+[testenv:py36]
 basepython = python3.6
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Reason: some servers send `'error': None`.