### PR TITLE
Fix deprecation warning

### DIFF
--- a/jsonrpc_base/jsonrpc.py
+++ b/jsonrpc_base/jsonrpc.py
@@ -100,7 +100,7 @@ class Server(object):
         # from the specs:
         # "If resent, parameters for the rpc call MUST be provided as a Structured value.
         #  Either by-position through an Array or by-name through an Object."
-        if len(args) == 1 and isinstance(args[0], collections.Mapping):
+        if len(args) == 1 and isinstance(args[0], collections.abc.Mapping):
             args = dict(args[0])
 
         return self.send_message(Request(method_name, args or kwargs, msg_id))


### PR DESCRIPTION
jsonrpc_base/jsonrpc.py:103: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working