### PR TITLE
Revert "Spec compliance: handle top-level mappings in function calls"

### DIFF
--- a/jsonrpc_base/jsonrpc.py
+++ b/jsonrpc_base/jsonrpc.py
@@ -1,4 +1,3 @@
-import collections
 import inspect
 import json
 import logging
@@ -134,13 +133,6 @@ class Server(object):
         if args and kwargs:
             raise ProtocolError(
                 'JSON-RPC spec forbids mixing arguments and keyword arguments')
-
-        # from the specs:
-        # "If resent, parameters for the rpc call MUST be provided as a
-        # Structured value.  Either by-position through an Array or by-name
-        # through an Object."
-        if len(args) == 1 and isinstance(args[0], collections.abc.Mapping):
-            args = dict(args[0])
 
         return self.send_message(Request(method_name, args or kwargs, msg_id))
 

--- a/tests.py
+++ b/tests.py
@@ -229,7 +229,7 @@ def test_calls(server):
 
     # rpc call with a mapping type
     def handler3(message):
-        assert message.params == {'foo': 'bar'}
+        assert message.params == [{'foo': 'bar'}]
         return {
             "jsonrpc": "2.0",
             "result": None,
@@ -238,6 +238,18 @@ def test_calls(server):
 
     server._handler = handler3
     server.foobar({'foo': 'bar'})
+
+    # rpc call with direct dict params
+    def handler3(message):
+        assert message.params == {'foo': 'bar'}
+        return {
+            "jsonrpc": "2.0",
+            "result": None,
+            "id": 1,
+        }
+
+    server._handler = handler3
+    server.foobar(**{'foo': 'bar'})
 
 
 def test_notification(server):


### PR DESCRIPTION
This reverts commit 52b3cb9a6ea7574f145b5d33f636538e91673824.

I'm not sure where this decision was originally made, but this logic is incorrect and unnecessary. Because we always load our parameters from *args, or **kwargs, we'll always pass either a tuple or dict, which means it'll always be a structured type per the spec.

See https://github.com/emlove/jsonrpc-websocket/issues/9