### PR TITLE
Omit empty "params" in requests

### DIFF
--- a/jsonrpc_base/jsonrpc.py
+++ b/jsonrpc_base/jsonrpc.py
@@ -193,7 +193,7 @@ class Request(Message):
     def serialize(self):
         """Generate the raw JSON message to be sent to the server"""
         data = {'jsonrpc': '2.0', 'method': self.method}
-        if self.params is not None:
+        if self.params:
             data['params'] = self.params
         if self.msg_id is not None:
             data['id'] = self.msg_id

--- a/tests.py
+++ b/tests.py
@@ -62,10 +62,15 @@ def test_dumps(server):
     )
     # test empty args dict
     assertSameJSON(
-        '''{"params": {}, "jsonrpc": "2.0", "method": "my_method_name", "id":
-        1}''',
+        '''{"jsonrpc": "2.0", "method": "my_method_name", "id": 1}''',
         jsonrpc_base.Request(
             'my_method_name', params={}, msg_id=1).serialize()
+    )
+    # test empty args array
+    assertSameJSON(
+        '''{"jsonrpc": "2.0", "method": "my_method_name", "id": 1}''',
+        jsonrpc_base.Request(
+            'my_method_name', params=[], msg_id=1).serialize()
     )
     # test keyword args
     assertSameJSON(


### PR DESCRIPTION
According to the JSON-RPC 2.0 Specification Section 4 (https://www.jsonrpc.org/specification#request_object) the "params" key may be omitted.

Closes #8